### PR TITLE
Use Nix flakes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1694422566,
+        "narHash": "sha256-lHJ+A9esOz9vln/3CJG23FV6Wd2OoOFbDeEs4cMGMqc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "3a2786eea085f040a66ecde1bc3ddc7099f6dbeb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+    description = "MrKonqi development shell";
+
+    inputs = {
+        nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    };
+
+    outputs = { self, nixpkgs }:
+    let
+        system = "x86_64-linux";
+        pkgs = nixpkgs.legacyPackages.${system};
+    in
+    {
+        devShells.${system}.default =
+            pkgs.mkShell {
+                buildInputs = [
+                    pkgs.nodejs_18
+                ];
+                shellHook = ''
+                    npm ci
+                '';
+            };
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,0 @@
-{ pkgs ? import <nixpkgs> {} }:
-  pkgs.mkShell {
-    nativeBuildInputs = with pkgs.buildPackages; [ nodejs_18 ];
-    shellHook = ''
-      npm install
-    '';
-}


### PR DESCRIPTION
Flakes allow for truly reproducible environments, since all inputs used in the flake (e.g. nixpkgs) are version-locked in the flake.lock file. Simply run `nix develop` to create a shell.

I've also changed the `npm install` command to `npm ci`.